### PR TITLE
Added clear function for clearing all timeouts

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,21 @@
     };
 
     /**
+     * @name Timeout
+     * @param fn
+     * @param interval
+     * @constructor
+     */
+    function Timeout(fn, interval) {
+        var id = setTimeout(fn, interval);
+        this.cleared = false;
+        this.clear = function() {
+            this.cleared = true;
+            clearTimeout(id);
+        };
+    }
+
+    /**
      * @name MutexPromise
      * @param key
      * @param [options]
@@ -41,6 +56,7 @@
         this._key = key;
         this._interval = options.interval || MutexPromise.interval;
         this._timeout = options.timeout || MutexPromise.timeout;
+        this._timeouts = [];
 
     }
 
@@ -86,6 +102,16 @@
     };
 
     /**
+     * 
+     */
+    MutexPromise.prototype.clear = function() {
+        this._timeouts.forEach(function(timeout) {
+            timeout.clear();
+        });
+        this._timeouts = [];
+    };
+
+    /**
      * @param {function} resolve
      * @param {function} reject
      * @private
@@ -95,7 +121,8 @@
             this.unlock();
             resolve(this);
         }
-        setTimeout(this._poll.bind(this, resolve, reject), this._interval);
+        var timeout = new Timeout(this._poll.bind(this, resolve, reject), this._interval);
+        this._timeouts.push(timeout);
     };
 
     /**

--- a/index.spec.js
+++ b/index.spec.js
@@ -125,4 +125,18 @@
 
     });
 
+    describe('clear()', function() {
+
+        it('clears all timeouts', function() {
+            var mutex = createMutex();
+            mutex.clear();
+            expect(mutex['_timeouts'].length).to.equal(0);
+        });
+
+        it('returns true for newly created and locked mutex', function() {
+            expect(createMutex().lock().locked()).to.be.true;
+        });
+
+    });
+
 }));


### PR DESCRIPTION
If one is using mutex to sync several actions (many calls to mutex.promise().then method), setting timeouts in private method _poll may fall in performance issues. In this code, MutexPromise manages a _timeouts array that populates with each invocation of _poll methods. A clear method has been implemented in order to be called when all actions had been performed and mutex is no longer needed.