### PR TITLE
add return on poll. causing openhandles

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@
     MutexPromise.prototype._poll = function(resolve, reject) {
         if (!this.locked()) {
             this.unlock();
-            resolve(this);
+            return resolve(this);
         }
         setTimeout(this._poll.bind(this, resolve, reject), this._interval);
     };


### PR DESCRIPTION
i see there is a openhandles causing `setTimeout` to be executed again after `resolve(this)`,
may `return` to break the function recursive